### PR TITLE
Improvements in toggl_webhooks.py and using logging instead of prints in lib

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -5,7 +5,9 @@
       "actions": ["INSERT", "UPDATE"],
       "models": ["time_entry"],
       "method": "POST",
-      "url": "https://www.example.com"
+      "url": "https://www.example.com",
+      "timeout": 10,
+      "trials": 3
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-dateutil==2.8.1
+requests==2.25.1
+websockets==8.1

--- a/toggl_webhooks.py
+++ b/toggl_webhooks.py
@@ -61,7 +61,7 @@ async def message_handler(action: str, model: str, method: str, url: str, msg: T
     assert trials > 1
     trial = 0
     while trial < trials:
-        res = requests.request(method, url, data=msg.to_dict(), **request_kwargs)
+        res = requests.request(method, url, json=msg.to_dict(), **request_kwargs)
         if res.status_code >= 400:
             print(f'{action} {model} -> {res.status_code} {method} {url} {res.text}')
             # retry after a while in case of bad response


### PR DESCRIPTION
* Trials in hitting webhook 
* Passing optional `**kwargs` in request (i.e. timeout, auth)
* Request webhook with JSON in body instead of form-data
* Catch exceptions while requesting webhook
* Using `logging` instead of `print`