### PR TITLE
Even more improvements

### DIFF
--- a/toggl_webhooks.py
+++ b/toggl_webhooks.py
@@ -93,7 +93,7 @@ async def message_handler(action: str, model: str, method: str, url: str, msg: T
             # retry after a while in case of bad response
             await asyncio.sleep(2 ** (trial - 1))
             continue
-        logger.info(f'{action} {model} -> {res.status_code} {method} {url}')
+        logger.info(f'{action} {model} -> {res.status_code} {method} {url} response: {res.text}')
         break
 
 

--- a/togglws/socket.py
+++ b/togglws/socket.py
@@ -24,7 +24,7 @@ class TogglSocketMessage:
             elif model == values.M_TAG:
                 return super(TogglSocketMessage, cls).__new__(TogglSocketTagMessage)
 
-        return super(TogglSocketMessage, cls).__new__(cls, model, definition)
+        return super(TogglSocketMessage, cls).__new__(cls)
 
     def __init__(self, model: str, definition):
         self.__model = model.lower()


### PR DESCRIPTION
* Log webhook's response after success
* Calling `TogglSocketMessage.__new__` fix

```
  File "toggl_webhooks/togglws/socket.py", line 27, in __new__
    return super(TogglSocketMessage, cls).__new__(cls, model, definition)
TypeError: object.__new__() takes exactly one argument (the type to instantiate)
```